### PR TITLE
Merge perlre and lol-re

### DIFF
--- a/lol-re.asd
+++ b/lol-re.asd
@@ -6,8 +6,14 @@
   :description "Small set of wrappers around CL-PPCRE in spirit of Let Over Lambda."
   :author "Alexander Popolitov <popolit@gmail.com>"
   :license "GPL"
-  :depends-on (#:cl-ppcre #:cl-interpol #:cl-read-macro-tokens #:defmacro-enhance #:alexandria
-			  #:iterate #:hu.dwim.walker)
+  :depends-on (#:cl-ppcre
+               #:cl-interpol
+               #:cl-read-macro-tokens
+               #:cl-syntax
+               #:defmacro-enhance
+               #:alexandria
+               #:iterate
+               #:hu.dwim.walker)
   :components ((:file "package")
                (:file "lol-re")))
 

--- a/lol-re.asd
+++ b/lol-re.asd
@@ -14,7 +14,8 @@
                #:alexandria
                #:iterate
                #:hu.dwim.walker)
-  :components ((:file "package")
+  :components ((:file "syntax")
+               (:file "package")
                (:file "lol-re")))
 
 

--- a/lol-re.asd
+++ b/lol-re.asd
@@ -9,7 +9,7 @@
   :depends-on (#:cl-ppcre
                #:cl-interpol
                #:cl-read-macro-tokens
-               #:cl-syntax
+               #:named-readtables
                #:defmacro-enhance
                #:alexandria
                #:iterate

--- a/syntax.lisp
+++ b/syntax.lisp
@@ -2,7 +2,12 @@
 (defpackage lol-re.syntax
   (:use cl)
   (:import-from defmacro-enhance
-                defmacro!))
+                defmacro!)
+  (:import-from cl-syntax
+                defsyntax)
+  (:import-from alexandria
+                symbolicate))
+
 (in-package lol-re.syntax)
 
 (defun segment-reader (strm ch n)
@@ -67,8 +72,8 @@
      (eval `(if (plusp (length ,m))
               (let ((ml (ppcre:split (format nil "(~a)" ,m) ,',str :with-registers-p t :limit 3))) ;for match-list
                 (let ,#1=(append
-                           (mapcar #`(,(lol:symb "$" a1) (xx ml ',a1)) '(\` & \'))
-                           (mapcar #`(,(lol:symb "$" a1) (aref ,a ,(1- a1))) (loop for i from 1 to (length a) collect i)))
+                           (mapcar #`(,(symbolicate "$" a1) (xx ml ',a1)) '(\` & \'))
+                           (mapcar #`(,(symbolicate "$" a1) (aref ,a ,(1- a1))) (loop for i from 1 to (length a) collect i)))
                   (declare (ignorable ,@(mapcar #'car #1#)))
                   ,',conseq))
               ,',altern))))
@@ -80,3 +85,7 @@
     (print $4))"#
   `(ifmatch (,test ,str)
      (progn ,conseq ,@more-conseq)))
+
+(defsyntax lol-re-syntax
+  (:merge :standard)
+  (:dispatch-macro-character #\# #\~ #'|#~-reader|))

--- a/syntax.lisp
+++ b/syntax.lisp
@@ -39,14 +39,22 @@
                 finally (unread-char c stm))
           'string))
 
-(set-dispatch-macro-character #\# #\~
-  (lambda (stm c n) (declare (ignore c n))
-    "dispatch function for #~"
-    (let ((mode-char (read-char stm)))
-      (case mode-char
-        (#\m (match-mode-ppcre-lambda-form (segment-reader stm (read-char stm) 1) (mods stm)))
-        (#\s (subst-mode-ppcre-lambda-form (segment-reader stm (read-char stm) 2) (mods stm)))
-        (t (error "Unknown #~~ mode character"))))))
+(defun |#~-reader| (stream char numarg)
+  (declare (ignore numarg))
+  (print char)
+  (let ((mode-char (read-char stream)))
+    (case mode-char
+      (#\m (match-mode-ppcre-lambda-form (segment-reader stream
+                                                         (read-char stream)
+                                                         1)
+                                         (mods stream)))
+      (#\s (subst-mode-ppcre-lambda-form (segment-reader stream
+                                                         (read-char stream)
+                                                         2)
+                                         (mods stream)))
+      (t (error "Unknown #~~ mode character")))))
+
+
 
 (defun xx (l i)
   (case i

--- a/syntax.lisp
+++ b/syntax.lisp
@@ -4,8 +4,8 @@
   (:use cl)
   (:import-from defmacro-enhance
                 defmacro!)
-  (:import-from cl-syntax
-                defsyntax)
+  (:import-from named-readtables
+                defreadtable)
   (:import-from alexandria
                 symbolicate)
   (:export lol-re-syntax))
@@ -98,6 +98,6 @@
   `(ifmatch (,test ,str)
      (progn ,@forms)))
 
-(defsyntax lol-re-syntax
+(defreadtable lol-re-syntax
   (:merge :standard)
   (:dispatch-macro-char #\# #\~ #'|#~-reader|))

--- a/syntax.lisp
+++ b/syntax.lisp
@@ -23,9 +23,9 @@
 
 (lol:defmacro! subst-mode-ppcre-lambda-form (o!args o!mods)
   ``(lambda (,',g!str)
-      (if (find #\g ,,g!mods)
-        (ppcre:regex-replace-all ,,regex ,',g!str ,(cadr ,g!args))
-        (ppcre:regex-replace ,,regex ,',g!str ,(cadr ,g!args)))))
+      ,(if (find #\g ,g!mods)
+           `(ppcre:regex-replace-all ,,regex ,',g!str ,(cadr ,g!args))
+           `(ppcre:regex-replace ,,regex ,',g!str ,(cadr ,g!args)))))
 
 (lol:defmacro! match-mode-ppcre-lambda-form (o!args o!mods)
   ``(lambda (,',g!str)

--- a/syntax.lisp
+++ b/syntax.lisp
@@ -61,12 +61,6 @@
                                          (mods stream)))
       (t (error "Unknown #~~ mode character")))))
 
-(defun xx (l i)
-  (case i
-    (\` (first l))
-    (& (second l))
-    (\' (third l))))
-
 (defmacro ifmatch ((test str) then &optional else)
   "Checks for the existence of group-capturing regex (in /for(bar)baz/, bar is capured) in the TEST and bind $1, $2, $n vars to the captured regex. Obviously, doesn't work with runtime regexes"
   (let* ((regexp (second (third test)))
@@ -77,9 +71,9 @@
                               (print regex-paretheses)
                               (length regex-paretheses))))
          ($-vars-let-form
-          (append '((|$`| (xx match-list '|`|))
-                    ($& (xx match-list '&))
-                    (|$'| (xx match-list '|'|)))
+          (append '((|$`| (first match-list))
+                    ($&   (second match-list))
+                    (|$'| (third match-list)))
                   (when how-many-$-vars
                     (mapcar (lambda (var-num)
                               `(,(symbolicate "$"

--- a/syntax.lisp
+++ b/syntax.lisp
@@ -88,4 +88,4 @@
 
 (defsyntax lol-re-syntax
   (:merge :standard)
-  (:dispatch-macro-character #\# #\~ #'|#~-reader|))
+  (:dispatch-macro-character #\# #\g #'|#~-reader|))

--- a/syntax.lisp
+++ b/syntax.lisp
@@ -90,9 +90,6 @@
              ,then)
            ,else))))
 
-(ifmatch (#~m/"(b)(c)(d)(e)"/ "abcdef")
-         (list $\` $& $\' $1 $2 $3 $4))
-
 (defmacro whenmatch ((test str) &body forms)
   "(whenmatch (#~m/\"(b)(c)(d)(e)\"/ \"abcdef\")
      (print |$`|)

--- a/syntax.lisp
+++ b/syntax.lisp
@@ -8,7 +8,6 @@
   (:import-from alexandria
                 symbolicate)
   (:export lol-re-syntax))
-
 (in-package lol-re.syntax)
 
 (defun segment-reader (stream ch n)
@@ -16,13 +15,14 @@
   (if (> n 0)
     (let (chars)
       (do ((curr #1=(read-char stream) #1#))
-        ((char= ch curr))
+          ((char= ch curr))
         (push curr chars))
       (if (char= ch #\')
-        (cons (coerce (nreverse chars) 'string) (segment-reader stream ch (1- n)))
-        (cons (with-input-from-string (s (coerce (nreverse chars) 'string))
-                (read s))
-              (segment-reader stream ch (1- n)))))))
+          (cons (coerce (nreverse chars) 'string)
+                (segment-reader stream ch (1- n)))
+          (cons (with-input-from-string (s (coerce (nreverse chars) 'string))
+                  (read s))
+                (segment-reader stream ch (1- n)))))))
 
 (define-symbol-macro regex
     `(if (zerop (length ,o!-mods))

--- a/syntax.lisp
+++ b/syntax.lisp
@@ -77,7 +77,9 @@
                               (print regex-paretheses)
                               (length regex-paretheses))))
          ($-vars-let-form
-          (append '((|$`| (XX ML '|`|)) ($& (XX ML '&)) (|$'| (XX ML '|'|)))
+          (append '((|$`| (xx match-list '|`|))
+                    ($& (xx match-list '&))
+                    (|$'| (xx match-list '|'|)))
                   (when how-many-$-vars
                     (mapcar (lambda (var-num)
                               `(,(symbolicate "$"
@@ -88,8 +90,10 @@
        (if (plusp (length matches))
            (let* ((match-list (ppcre:split (format nil "(~a)" matches)
                                            ,str :with-registers-p t :limit 3))
-                  (declare (ignorable ,@(mapcar #'car $-vars-let-form)))
-                  ,then))
+                  ,@$-vars-let-form)
+
+             (declare (ignorable ,@(mapcar #'car $-vars-let-form)))
+             ,then)
            ,else))))
 
 (defmacro whenmatch ((test str) &body forms)

--- a/syntax.lisp
+++ b/syntax.lisp
@@ -1,4 +1,5 @@
 ;;; Taken from https://github.com/jschatzer/perlre/blob/master/perlre.lisp
+;; Authors: Doug Hoyte, jschatzer and André Miranda.
 (defpackage lol-re.syntax
   (:use cl)
   (:import-from defmacro-enhance

--- a/syntax.lisp
+++ b/syntax.lisp
@@ -67,6 +67,7 @@
     (\' (third l))))
 
 (defmacro ifmatch ((test str) then &optional else)
+  "Checks for the existence of group-capturing regex (in /for(bar)baz/, bar is capured) in the TEST and bind $1, $2, $n vars to the captured regex. Obviously, doesn't work with runtime regexes"
   (let* ((regexp (second (third test)))
          (how-many-$-vars (when (stringp regexp)
                             (let ((regex-paretheses

--- a/syntax.lisp
+++ b/syntax.lisp
@@ -1,0 +1,74 @@
+;;; Taken from https://github.com/jschatzer/perlre/blob/master/perlre.lisp
+(defpackage lol-re.syntax
+  (:use cl))
+(in-package lol-re.syntax)
+
+(defun segment-reader (strm ch n)
+  "with m'' or s''' supress string interpolation, camel192"
+  (if (> n 0)
+    (let (chars)
+      (do ((curr #1=(read-char strm) #1#))
+        ((char= ch curr))
+        (push curr chars))
+      (if (char= ch #\')
+        (cons (coerce (nreverse chars) 'string) (segment-reader strm ch (1- n)))
+        (cons (with-input-from-string (s (coerce (nreverse chars) 'string)) (read s))
+              (segment-reader strm ch (1- n)))))))
+
+(define-symbol-macro
+  regex
+  `(if (zerop (length ,g!mods))
+     (car ,g!args)
+     (format nil "(?~a)~a" (remove #\g ,g!mods) (car ,g!args))))
+
+(lol:defmacro! subst-mode-ppcre-lambda-form (o!args o!mods)
+  ``(lambda (,',g!str)
+      (if (find #\g ,,g!mods)
+        (ppcre:regex-replace-all ,,regex ,',g!str ,(cadr ,g!args))
+        (ppcre:regex-replace ,,regex ,',g!str ,(cadr ,g!args)))))
+
+(lol:defmacro! match-mode-ppcre-lambda-form (o!args o!mods)
+  ``(lambda (,',g!str)
+      (ppcre:scan-to-strings ,,regex ,',g!str)))
+
+(defun mods (stm)
+  "imsxg modifiers"
+  (coerce (loop for c = (read-char stm)
+                while (alpha-char-p c) collect c
+                finally (unread-char c stm))
+          'string))
+
+(set-dispatch-macro-character #\# #\~
+  (lambda (stm c n) (declare (ignore c n))
+    "dispatch function for #~"
+    (let ((mode-char (read-char stm)))
+      (case mode-char
+        (#\m (match-mode-ppcre-lambda-form (segment-reader stm (read-char stm) 1) (mods stm)))
+        (#\s (subst-mode-ppcre-lambda-form (segment-reader stm (read-char stm) 2) (mods stm)))
+        (t (error "Unknown #~~ mode character"))))))
+
+(defun xx (l i)
+  (case i
+    (\` (first l))
+    (& (second l))
+    (\' (third l))))
+
+; for now without gensyms, 15.12.14
+(lol:defmacro! ifmatch ((test str) conseq &optional altern)
+  `(multiple-value-bind (m a) (,test ,str) ; for match and array
+     (eval `(if (plusp (length ,m))
+              (let ((ml (ppcre:split (format nil "(~a)" ,m) ,',str :with-registers-p t :limit 3))) ;for match-list
+                (let ,#1=(append
+                           (mapcar #`(,(lol:symb "$" a1) (xx ml ',a1)) '(\` & \'))
+                           (mapcar #`(,(lol:symb "$" a1) (aref ,a ,(1- a1))) (loop for i from 1 to (length a) collect i)))
+                  (declare (ignorable ,@(mapcar #'car #1#)))
+                  ,',conseq))
+              ,',altern))))
+
+(defmacro whenmatch ((test str) conseq &rest more-conseq)
+  #"(whenmatch (#~m/"(b)(c)(d)(e)"/ "abcdef")
+    (print |$`|)
+    (print $2)
+    (print $4))"#
+  `(ifmatch (,test ,str)
+     (progn ,conseq ,@more-conseq)))


### PR DESCRIPTION
This pull request adds the syntax.lisp file, merging perlre and lol-re projects, fixing [#882](https://github.com/quicklisp/quicklisp-projects/issues/822) from quicklisp-projects.

A few chages were made to the original perlre project:
1. Instead of changing the readtable at load-time, it uses the [cl-syntax](https://github.com/m2ym/cl-syntax) library to handle the `*readtable*`;
2. A few arg names were chaged for a better name (in my opinion): `stm`, `strm` and alike changed to `stream`, etc.;
3. Changed from `lol:defmacro!` to `defmacro-enhance:defmacro!`: the former changes the readtable when loading and is less portable, while the latter is more widely used (even already being used by the lol-re library);
4. The decision between `#'REGEX-REPLACE` and `#'REGEX-REPLACE-ALL` was changed from run-time (inside the lambda form) to read-time;
5. The if match macro was completly reformulated: is used an eval to run all the real code at run-time!. All the variables that one can want to group-capture ($1, $2, etc.) are decided at run-time: a regex for parsing regexes is used to find matching parentheses inside the regex. According to the amount of matches that are found, it binds that amount of (local) variables.

Still need to add some docstrings add tutorial in the README. I plan on doing it soon. Should I go on?